### PR TITLE
Bump bindgen build-dependency to handle clang naming breaking change

### DIFF
--- a/libvex-rs/src/lib.rs
+++ b/libvex-rs/src/lib.rs
@@ -22,7 +22,7 @@ pub mod ppc64;
 pub mod s390x;
 pub mod x86;
 
-unsafe extern "C" fn failure_exit() {
+unsafe extern "C" fn failure_exit() -> ! {
     panic!("LibVEX encountered a critical error.")
 }
 

--- a/libvex-sys/Cargo.toml
+++ b/libvex-sys/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2.85"
 
 [build-dependencies]
 fs_extra = "1.2"
-bindgen = "0.57"
+bindgen = "0.69"
 
 [features]
 default = []

--- a/libvex-sys/build.rs
+++ b/libvex-sys/build.rs
@@ -134,14 +134,14 @@ fn main() -> Result<()> {
         // Generate bindings
         let bindings = bindgen::Builder::default()
             .header("wrapper.h")
-            .blacklist_type("_IRStmt__bindgen_ty_1__bindgen_ty_1")
-            .rustified_enum("*")
+            .blocklist_type("_IRStmt__bindgen_ty_1__bindgen_ty_1")
+            .rustified_enum(".*")
             .clang_args(vex_headers()?
                         .into_iter()
                         .map(|dir| format!("-I{}", dir))
             )
             .generate()
-            .map_err(|()| "Unable to generate bindings")?;
+            .map_err(|_| "Unable to generate bindings")?;
         bindings.write_to_file(out_dir.join("bindings.rs"))?;
     }
 

--- a/libvex-sys/src/lib.rs
+++ b/libvex-sys/src/lib.rs
@@ -36,7 +36,7 @@ mod test {
 
     use crate::*;
 
-    unsafe extern "C" fn failure_exit() {
+    unsafe extern "C" fn failure_exit() -> ! {
         panic!("LibVEX encountered a critical error.")
     }
 


### PR DESCRIPTION
Thanks for this crate !

2 years ago, clang changed the way it names anonymous struct. 
This crate doesn't compile with recent clang versions, the bindgen crate now handle this issue.

The bindgen issue : https://github.com/rust-lang/rust-bindgen/issues/2312